### PR TITLE
feat(web): wire detail link and upvote button in map popup

### DIFF
--- a/apps/web/src/components/issue-map.test.tsx
+++ b/apps/web/src/components/issue-map.test.tsx
@@ -1,0 +1,86 @@
+import { screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import type { Report } from "@/api/reports";
+import { getCategories } from "@/api/categories";
+import { getReports } from "@/api/reports";
+import { renderWithQuery } from "@/test/test-utils";
+import IssueMap from "./issue-map";
+
+vi.mock("@/api/reports", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/api/reports")>();
+  return { ...actual, getReports: vi.fn(), voteOnReport: vi.fn() };
+});
+
+vi.mock("@/api/categories", () => ({
+  getCategories: vi.fn(),
+  getReportsByCategory: vi.fn(),
+}));
+
+vi.mock("@/lib/auth-client", () => ({
+  useSession: () => ({ data: { user: { id: "usr_1" } }, isPending: false }),
+}));
+
+vi.mock("@tanstack/react-router", () => ({
+  Link: ({ children, to, params }: { children: React.ReactNode; to: string; params?: Record<string, string> }) => {
+    const href = params ? Object.entries(params).reduce((acc, [k, v]) => acc.replace(`$${k}`, v), to) : to;
+    return <a href={href}>{children}</a>;
+  },
+}));
+
+vi.mock("react-leaflet", () => ({
+  MapContainer: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  TileLayer: () => null,
+  Marker: ({ children }: { children?: React.ReactNode }) => <div>{children}</div>,
+  Popup: ({ children }: { children: React.ReactNode }) => (
+    <div data-testid="popup">{children}</div>
+  ),
+}));
+
+const mockedGetReports = vi.mocked(getReports);
+const mockedGetCategories = vi.mocked(getCategories);
+
+function makeReport(overrides: Partial<Report> = {}): Report {
+  return {
+    id: "rep_42",
+    title: "Buraco grande",
+    lat: -3.92,
+    lng: -39.55,
+    status: "active",
+    credibility: 50,
+    upvotes: 8,
+    categoryId: "cat_1",
+    expiresAt: null,
+    createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(),
+    ...overrides,
+  };
+}
+
+describe("IssueMap popup", () => {
+  it("renders a link to the report detail page", async () => {
+    mockedGetCategories.mockResolvedValue([]);
+    mockedGetReports.mockResolvedValue({
+      data: [makeReport({ id: "rep_42" })],
+      pagination: { total: 1, page: 1, limit: 100, offset: 0 },
+    });
+
+    renderWithQuery(<IssueMap />);
+
+    const link = await screen.findByRole("link", { name: /ver detalhes/i });
+    expect(link).toHaveAttribute("href", "/reports/rep_42");
+  });
+
+  it("renders an upvote button inside the popup", async () => {
+    mockedGetCategories.mockResolvedValue([]);
+    mockedGetReports.mockResolvedValue({
+      data: [makeReport({ upvotes: 8 })],
+      pagination: { total: 1, page: 1, limit: 100, offset: 0 },
+    });
+
+    renderWithQuery(<IssueMap />);
+
+    expect(await screen.findByRole("button", { name: /confirmar/i })).toBeInTheDocument();
+    expect(screen.getByText("8")).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/components/issue-map.tsx
+++ b/apps/web/src/components/issue-map.tsx
@@ -1,5 +1,6 @@
 import "leaflet/dist/leaflet.css";
 
+import { Link } from "@tanstack/react-router";
 import L from "leaflet";
 import { useEffect, useMemo, useState } from "react";
 import { MapContainer, Marker, Popup, TileLayer } from "react-leaflet";
@@ -7,6 +8,7 @@ import { MapContainer, Marker, Popup, TileLayer } from "react-leaflet";
 import { getReports, type Report } from "@/api/reports";
 import { getCategories, getReportsByCategory, type Category } from "@/api/categories";
 import { CENTRO_CENTER } from "@/lib/geofencing";
+import { UpvoteButton } from "./upvote-button";
 
 const pin = L.icon({
   iconUrl: "/pinmap.svg",
@@ -98,8 +100,12 @@ export default function IssueMap() {
                 <p>
                   {report.categoryId ? categoriesById[report.categoryId] ?? "" : ""}
                 </p>
+                <p>credibilidade {report.credibility}</p>
+                <UpvoteButton report={{ id: report.id, upvotes: report.upvotes }} />
                 <p>
-                  {report.upvotes} confirmações · credibilidade {report.credibility}
+                  <Link to="/reports/$id" params={{ id: report.id }}>
+                    Ver detalhes →
+                  </Link>
                 </p>
               </Popup>
             </Marker>


### PR DESCRIPTION
https://github.com/EricmesquiBR/itareport-monorepo/issues/55

### Background

Until now the popup that opens when you click a marker was a dead end: it showed the title, category, and a static count, with no way to actually do anything. This PR wires the popup to the rest of the Phase 2 work by dropping in the shared `UpvoteButton` for one-click confirmation and a `Ver detalhes →` link to the new `/reports/$id` route.

The implementation is a small surgical edit on `IssueMap`. The static "X confirmações" line is removed because the button itself now exposes the live count, so keeping the text would just duplicate state.

### Key Decisions

1. **Stacked on `feat/web-report-detail`**: the popup link points to the route that PR #63 ships, so this branch sits on top of it; rebase onto `dev` once both predecessors land.
2. **Drop the static upvote count**: `UpvoteButton` already renders the count and updates it optimistically, so showing the same number twice would drift the moment a vote is confirmed.