### PR TITLE
feat(web): land /reports/$id route and updated map popup on dev

### DIFF
--- a/apps/web/src/components/issue-map.test.tsx
+++ b/apps/web/src/components/issue-map.test.tsx
@@ -1,0 +1,86 @@
+import { screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import type { Report } from "@/api/reports";
+import { getCategories } from "@/api/categories";
+import { getReports } from "@/api/reports";
+import { renderWithQuery } from "@/test/test-utils";
+import IssueMap from "./issue-map";
+
+vi.mock("@/api/reports", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/api/reports")>();
+  return { ...actual, getReports: vi.fn(), voteOnReport: vi.fn() };
+});
+
+vi.mock("@/api/categories", () => ({
+  getCategories: vi.fn(),
+  getReportsByCategory: vi.fn(),
+}));
+
+vi.mock("@/lib/auth-client", () => ({
+  useSession: () => ({ data: { user: { id: "usr_1" } }, isPending: false }),
+}));
+
+vi.mock("@tanstack/react-router", () => ({
+  Link: ({ children, to, params }: { children: React.ReactNode; to: string; params?: Record<string, string> }) => {
+    const href = params ? Object.entries(params).reduce((acc, [k, v]) => acc.replace(`$${k}`, v), to) : to;
+    return <a href={href}>{children}</a>;
+  },
+}));
+
+vi.mock("react-leaflet", () => ({
+  MapContainer: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  TileLayer: () => null,
+  Marker: ({ children }: { children?: React.ReactNode }) => <div>{children}</div>,
+  Popup: ({ children }: { children: React.ReactNode }) => (
+    <div data-testid="popup">{children}</div>
+  ),
+}));
+
+const mockedGetReports = vi.mocked(getReports);
+const mockedGetCategories = vi.mocked(getCategories);
+
+function makeReport(overrides: Partial<Report> = {}): Report {
+  return {
+    id: "rep_42",
+    title: "Buraco grande",
+    lat: -3.92,
+    lng: -39.55,
+    status: "active",
+    credibility: 50,
+    upvotes: 8,
+    categoryId: "cat_1",
+    expiresAt: null,
+    createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(),
+    ...overrides,
+  };
+}
+
+describe("IssueMap popup", () => {
+  it("renders a link to the report detail page", async () => {
+    mockedGetCategories.mockResolvedValue([]);
+    mockedGetReports.mockResolvedValue({
+      data: [makeReport({ id: "rep_42" })],
+      pagination: { total: 1, page: 1, limit: 100, offset: 0 },
+    });
+
+    renderWithQuery(<IssueMap />);
+
+    const link = await screen.findByRole("link", { name: /ver detalhes/i });
+    expect(link).toHaveAttribute("href", "/reports/rep_42");
+  });
+
+  it("renders an upvote button inside the popup", async () => {
+    mockedGetCategories.mockResolvedValue([]);
+    mockedGetReports.mockResolvedValue({
+      data: [makeReport({ upvotes: 8 })],
+      pagination: { total: 1, page: 1, limit: 100, offset: 0 },
+    });
+
+    renderWithQuery(<IssueMap />);
+
+    expect(await screen.findByRole("button", { name: /confirmar/i })).toBeInTheDocument();
+    expect(screen.getByText("8")).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/components/issue-map.tsx
+++ b/apps/web/src/components/issue-map.tsx
@@ -1,5 +1,6 @@
 import "leaflet/dist/leaflet.css";
 
+import { Link } from "@tanstack/react-router";
 import L from "leaflet";
 import { useEffect, useMemo, useState } from "react";
 import { MapContainer, Marker, Popup, TileLayer } from "react-leaflet";
@@ -7,6 +8,7 @@ import { MapContainer, Marker, Popup, TileLayer } from "react-leaflet";
 import { getReports, type Report } from "@/api/reports";
 import { getCategories, getReportsByCategory, type Category } from "@/api/categories";
 import { CENTRO_CENTER } from "@/lib/geofencing";
+import { UpvoteButton } from "./upvote-button";
 
 const pin = L.icon({
   iconUrl: "/pinmap.svg",
@@ -98,8 +100,12 @@ export default function IssueMap() {
                 <p>
                   {report.categoryId ? categoriesById[report.categoryId] ?? "" : ""}
                 </p>
+                <p>credibilidade {report.credibility}</p>
+                <UpvoteButton report={{ id: report.id, upvotes: report.upvotes }} />
                 <p>
-                  {report.upvotes} confirmações · credibilidade {report.credibility}
+                  <Link to="/reports/$id" params={{ id: report.id }}>
+                    Ver detalhes →
+                  </Link>
                 </p>
               </Popup>
             </Marker>

--- a/apps/web/src/components/report-detail.test.tsx
+++ b/apps/web/src/components/report-detail.test.tsx
@@ -1,0 +1,149 @@
+import { screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { ReportWithImages } from "@/api/reports";
+import { getReportById } from "@/api/reports";
+import { renderWithQuery } from "@/test/test-utils";
+import { ReportDetail } from "./report-detail";
+
+vi.mock("@/api/reports", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/api/reports")>();
+  return { ...actual, getReportById: vi.fn() };
+});
+
+vi.mock("@/lib/auth-client", () => ({
+  useSession: () => ({ data: { user: { id: "usr_1" } }, isPending: false }),
+}));
+
+vi.mock("react-leaflet", () => ({
+  MapContainer: ({ children }: { children: React.ReactNode }) => (
+    <div data-testid="map">{children}</div>
+  ),
+  TileLayer: () => null,
+  Marker: () => <div data-testid="marker" />,
+}));
+
+vi.mock("@tanstack/react-router", () => ({
+  Link: ({ children, to }: { children: React.ReactNode; to: string }) => (
+    <a href={to}>{children}</a>
+  ),
+}));
+
+const mockedGet = vi.mocked(getReportById);
+
+function makeReport(overrides: Partial<ReportWithImages> = {}): ReportWithImages {
+  return {
+    id: "rep_1",
+    title: "Buraco na Av. Brasil",
+    lat: -3.92,
+    lng: -39.55,
+    status: "active",
+    credibility: 42,
+    upvotes: 5,
+    categoryId: "cat_1",
+    expiresAt: "2026-05-05T12:00:00Z",
+    createdAt: "2026-04-25T12:00:00Z",
+    updatedAt: "2026-04-28T12:00:00Z",
+    images: [],
+    ...overrides,
+  };
+}
+
+describe("ReportDetail", () => {
+  beforeEach(() => {
+    vi.useFakeTimers({ toFake: ["Date"] });
+    vi.setSystemTime(new Date("2026-04-28T12:00:00Z"));
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("renders the report title once loaded", async () => {
+    mockedGet.mockResolvedValueOnce(makeReport({ title: "Buraco na Av. Brasil" }));
+
+    renderWithQuery(<ReportDetail id="rep_1" />);
+
+    expect(await screen.findByRole("heading", { name: "Buraco na Av. Brasil" })).toBeInTheDocument();
+  });
+
+  it("shows a not-found message when the API returns 404", async () => {
+    mockedGet.mockRejectedValueOnce(
+      Object.assign(new Error("not found"), { response: { status: 404 } }),
+    );
+
+    renderWithQuery(<ReportDetail id="rep_missing" />);
+
+    expect(
+      await screen.findByText(/reporte não encontrado ou expirado/i),
+    ).toBeInTheDocument();
+  });
+
+  it("shows a loading state while the request is in flight", () => {
+    mockedGet.mockImplementationOnce(() => new Promise(() => {}));
+
+    renderWithQuery(<ReportDetail id="rep_1" />);
+
+    expect(screen.getByRole("status")).toBeInTheDocument();
+  });
+
+  it("renders an active status badge with the active label", async () => {
+    mockedGet.mockResolvedValueOnce(makeReport({ status: "active" }));
+
+    renderWithQuery(<ReportDetail id="rep_1" />);
+
+    expect(await screen.findByText("Confirmado")).toBeInTheDocument();
+  });
+
+  it("renders a pending status badge with the pending label", async () => {
+    mockedGet.mockResolvedValueOnce(makeReport({ status: "pending" }));
+
+    renderWithQuery(<ReportDetail id="rep_1" />);
+
+    expect(await screen.findByText("Em validação")).toBeInTheDocument();
+  });
+
+  it("shows credibility and the upvote button with the current count", async () => {
+    mockedGet.mockResolvedValueOnce(makeReport({ upvotes: 12, credibility: 73 }));
+
+    renderWithQuery(<ReportDetail id="rep_1" />);
+
+    expect(await screen.findByText(/credibilidade.*73/i)).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /confirmar/i })).toBeInTheDocument();
+    expect(screen.getByText("12")).toBeInTheDocument();
+  });
+
+  it("shows created and expires dates as relative pt-BR", async () => {
+    mockedGet.mockResolvedValueOnce(makeReport());
+
+    renderWithQuery(<ReportDetail id="rep_1" />);
+
+    expect(await screen.findByText(/Criado há 3 dias/i)).toBeInTheDocument();
+    expect(screen.getByText(/Expira em 7 dias/i)).toBeInTheDocument();
+  });
+
+  it("renders the primary image when available", async () => {
+    mockedGet.mockResolvedValueOnce(
+      makeReport({
+        images: [
+          { id: "img_1", storageKey: "reports/2026-04-25/photo.webp", isPrimary: true },
+        ],
+      }),
+    );
+
+    renderWithQuery(<ReportDetail id="rep_1" />);
+
+    const img = await screen.findByRole("img");
+    expect(img).toHaveAttribute("src", expect.stringContaining("reports/2026-04-25/photo.webp"));
+  });
+
+  it("renders a mini-map with a marker and a back link", async () => {
+    mockedGet.mockResolvedValueOnce(makeReport());
+
+    renderWithQuery(<ReportDetail id="rep_1" />);
+
+    expect(await screen.findByTestId("map")).toBeInTheDocument();
+    expect(screen.getByTestId("marker")).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: /voltar ao mapa/i })).toHaveAttribute("href", "/map");
+  });
+});

--- a/apps/web/src/components/report-detail.tsx
+++ b/apps/web/src/components/report-detail.tsx
@@ -1,0 +1,60 @@
+import { useQuery } from "@tanstack/react-query";
+import { Link } from "@tanstack/react-router";
+import { MapContainer, Marker, TileLayer } from "react-leaflet";
+
+import { getReportById, imageUrl } from "@/api/reports";
+import { formatRelative } from "@/lib/relative-time";
+import { StatusBadge } from "./status-badge";
+import { UpvoteButton } from "./upvote-button";
+
+type ReportDetailProps = { id: string };
+
+function isNotFound(error: unknown): boolean {
+  return (
+    typeof error === "object" &&
+    error !== null &&
+    "response" in error &&
+    (error as { response?: { status?: number } }).response?.status === 404
+  );
+}
+
+export function ReportDetail({ id }: ReportDetailProps) {
+  const { data, error, isError } = useQuery({
+    queryKey: ["report", id],
+    queryFn: () => getReportById(id),
+  });
+
+  if (isError && isNotFound(error)) {
+    return <p>Reporte não encontrado ou expirado.</p>;
+  }
+
+  if (!data) {
+    return <div role="status">Carregando…</div>;
+  }
+
+  const primary = data.images.find((img) => img.isPrimary) ?? data.images[0];
+
+  return (
+    <div className="max-w-3xl mx-auto p-4">
+      <Link to="/map">← Voltar ao mapa</Link>
+      <h1>{data.title}</h1>
+      <StatusBadge status={data.status} />
+      {primary && (
+        <img src={imageUrl(primary.storageKey)} alt={data.title} className="rounded my-4" />
+      )}
+      <p>Credibilidade: {data.credibility}</p>
+      <p>Criado {formatRelative(data.createdAt)}</p>
+      {data.expiresAt && <p>Expira {formatRelative(data.expiresAt)}</p>}
+      <UpvoteButton report={{ id: data.id, upvotes: data.upvotes }} />
+      <div className="h-64 my-4">
+        <MapContainer center={[data.lat, data.lng]} zoom={16} scrollWheelZoom={false}>
+          <TileLayer
+            attribution='&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors'
+            url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"
+          />
+          <Marker position={[data.lat, data.lng]} />
+        </MapContainer>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/components/status-badge.tsx
+++ b/apps/web/src/components/status-badge.tsx
@@ -1,0 +1,21 @@
+import type { ReportStatus } from "@/api/reports";
+
+const LABELS: Record<ReportStatus, string> = {
+  pending: "Em validação",
+  active: "Confirmado",
+  expired: "Expirado",
+};
+
+const CLASSES: Record<ReportStatus, string> = {
+  pending: "bg-gray-200 text-gray-800",
+  active: "bg-green-200 text-green-900",
+  expired: "bg-zinc-300 text-zinc-700",
+};
+
+export function StatusBadge({ status }: { status: ReportStatus }) {
+  return (
+    <span className={`inline-block px-2 py-0.5 rounded text-xs font-medium ${CLASSES[status]}`}>
+      {LABELS[status]}
+    </span>
+  );
+}

--- a/apps/web/src/lib/relative-time.test.ts
+++ b/apps/web/src/lib/relative-time.test.ts
@@ -1,0 +1,22 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { formatRelative } from "./relative-time";
+
+describe("formatRelative", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-04-28T12:00:00Z"));
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("formats a past date as days ago in pt-BR", () => {
+    expect(formatRelative("2026-04-25T12:00:00Z")).toBe("há 3 dias");
+  });
+
+  it("formats a future date as days ahead in pt-BR", () => {
+    expect(formatRelative("2026-05-05T12:00:00Z")).toBe("em 7 dias");
+  });
+});

--- a/apps/web/src/lib/relative-time.ts
+++ b/apps/web/src/lib/relative-time.ts
@@ -1,0 +1,25 @@
+const formatter = new Intl.RelativeTimeFormat("pt-BR", { numeric: "always" });
+
+const UNITS: Array<{ unit: Intl.RelativeTimeFormatUnit; ms: number }> = [
+  { unit: "year", ms: 365 * 24 * 60 * 60 * 1000 },
+  { unit: "month", ms: 30 * 24 * 60 * 60 * 1000 },
+  { unit: "day", ms: 24 * 60 * 60 * 1000 },
+  { unit: "hour", ms: 60 * 60 * 1000 },
+  { unit: "minute", ms: 60 * 1000 },
+  { unit: "second", ms: 1000 },
+];
+
+export function formatRelative(input: Date | string): string {
+  const date = typeof input === "string" ? new Date(input) : input;
+  const diffMs = date.getTime() - Date.now();
+  const absMs = Math.abs(diffMs);
+
+  for (const { unit, ms } of UNITS) {
+    if (absMs >= ms || unit === "second") {
+      const value = Math.round(diffMs / ms);
+      return formatter.format(value, unit);
+    }
+  }
+
+  return formatter.format(0, "second");
+}

--- a/apps/web/src/routeTree.gen.ts
+++ b/apps/web/src/routeTree.gen.ts
@@ -15,6 +15,7 @@ import { Route as MapRouteImport } from "./routes/map"
 import { Route as LoginRouteImport } from "./routes/login"
 import { Route as AboutRouteImport } from "./routes/about"
 import { Route as IndexRouteImport } from "./routes/index"
+import { Route as ReportsIdRouteImport } from "./routes/reports.$id"
 
 const ReportFormRoute = ReportFormRouteImport.update({
   id: "/report-form",
@@ -46,6 +47,11 @@ const IndexRoute = IndexRouteImport.update({
   path: "/",
   getParentRoute: () => rootRouteImport,
 } as any)
+const ReportsIdRoute = ReportsIdRouteImport.update({
+  id: "/reports/$id",
+  path: "/reports/$id",
+  getParentRoute: () => rootRouteImport,
+} as any)
 
 export interface FileRoutesByFullPath {
   "/": typeof IndexRoute
@@ -54,6 +60,7 @@ export interface FileRoutesByFullPath {
   "/map": typeof MapRoute
   "/register": typeof RegisterRoute
   "/report-form": typeof ReportFormRoute
+  "/reports/$id": typeof ReportsIdRoute
 }
 export interface FileRoutesByTo {
   "/": typeof IndexRoute
@@ -62,6 +69,7 @@ export interface FileRoutesByTo {
   "/map": typeof MapRoute
   "/register": typeof RegisterRoute
   "/report-form": typeof ReportFormRoute
+  "/reports/$id": typeof ReportsIdRoute
 }
 export interface FileRoutesById {
   __root__: typeof rootRouteImport
@@ -71,12 +79,27 @@ export interface FileRoutesById {
   "/map": typeof MapRoute
   "/register": typeof RegisterRoute
   "/report-form": typeof ReportFormRoute
+  "/reports/$id": typeof ReportsIdRoute
 }
 export interface FileRouteTypes {
   fileRoutesByFullPath: FileRoutesByFullPath
-  fullPaths: "/" | "/about" | "/login" | "/map" | "/register" | "/report-form"
+  fullPaths:
+    | "/"
+    | "/about"
+    | "/login"
+    | "/map"
+    | "/register"
+    | "/report-form"
+    | "/reports/$id"
   fileRoutesByTo: FileRoutesByTo
-  to: "/" | "/about" | "/login" | "/map" | "/register" | "/report-form"
+  to:
+    | "/"
+    | "/about"
+    | "/login"
+    | "/map"
+    | "/register"
+    | "/report-form"
+    | "/reports/$id"
   id:
     | "__root__"
     | "/"
@@ -85,6 +108,7 @@ export interface FileRouteTypes {
     | "/map"
     | "/register"
     | "/report-form"
+    | "/reports/$id"
   fileRoutesById: FileRoutesById
 }
 export interface RootRouteChildren {
@@ -94,6 +118,7 @@ export interface RootRouteChildren {
   MapRoute: typeof MapRoute
   RegisterRoute: typeof RegisterRoute
   ReportFormRoute: typeof ReportFormRoute
+  ReportsIdRoute: typeof ReportsIdRoute
 }
 
 declare module "@tanstack/react-router" {
@@ -140,6 +165,13 @@ declare module "@tanstack/react-router" {
       preLoaderRoute: typeof IndexRouteImport
       parentRoute: typeof rootRouteImport
     }
+    "/reports/$id": {
+      id: "/reports/$id"
+      path: "/reports/$id"
+      fullPath: "/reports/$id"
+      preLoaderRoute: typeof ReportsIdRouteImport
+      parentRoute: typeof rootRouteImport
+    }
   }
 }
 
@@ -150,6 +182,7 @@ const rootRouteChildren: RootRouteChildren = {
   MapRoute: MapRoute,
   RegisterRoute: RegisterRoute,
   ReportFormRoute: ReportFormRoute,
+  ReportsIdRoute: ReportsIdRoute,
 }
 export const routeTree = rootRouteImport
   ._addFileChildren(rootRouteChildren)

--- a/apps/web/src/routes/reports.$id.tsx
+++ b/apps/web/src/routes/reports.$id.tsx
@@ -1,0 +1,12 @@
+import { createFileRoute } from "@tanstack/react-router";
+
+import { ReportDetail } from "@/components/report-detail";
+
+export const Route = createFileRoute("/reports/$id")({
+  component: ReportDetailRoute,
+});
+
+function ReportDetailRoute() {
+  const { id } = Route.useParams();
+  return <ReportDetail id={id} />;
+}


### PR DESCRIPTION
Brings #53 and #55 onto \`dev\`. The original stacked PRs (#63, #64) were merged into their parent feature branches but never re-targeted to \`dev\` after #62 landed, so the changes were stuck in \`feat/web-report-detail\` and \`feat/web-map-popup-detail\`. This PR is a no-op rebase: same commits, just merged into the right branch.

Fixes the gap left by:
- https://github.com/EricmesquiBR/itareport-monorepo/pull/63 (closes #53)
- https://github.com/EricmesquiBR/itareport-monorepo/pull/64 (closes #55)

### Background

#62 merged the \`UpvoteButton\` into \`dev\`. The stack on top of it (report detail page, popup wiring) was approved and merged, but each PR targeted the previous feature branch instead of \`dev\`, so the cascade stopped after the first one. Since GitHub will not let an already-merged PR be reopened, the only way to forward the changes is a fresh PR pointing the tip of the stack at \`dev\`.

### Key Decisions

1. **Single PR for the remaining stack**: both review threads already approved the changes, so consolidating them into one merge keeps the history compact instead of opening two more PRs to chain back.