### PR TITLE
feat(web): /me account page + header link

### DIFF
--- a/apps/web/src/components/header.test.tsx
+++ b/apps/web/src/components/header.test.tsx
@@ -1,0 +1,65 @@
+import { render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import Header from "./header";
+
+type SessionState = {
+  data: { user: { id: string; name?: string; username?: string } } | null;
+  isPending: boolean;
+};
+const sessionState: { current: SessionState } = {
+  current: { data: null, isPending: false },
+};
+
+vi.mock("@/lib/auth-client", () => ({
+  useSession: () => sessionState.current,
+  signOut: vi.fn(),
+}));
+
+vi.mock("@tanstack/react-router", () => ({
+  Link: ({ children, to }: { children: React.ReactNode; to: string }) => (
+    <a href={to}>{children}</a>
+  ),
+  useNavigate: () => vi.fn(),
+}));
+
+function setSession(state: SessionState) {
+  sessionState.current = state;
+}
+
+describe("Header", () => {
+  beforeEach(() => {
+    setSession({ data: null, isPending: false });
+  });
+
+  it("links the logged-in username to /me", () => {
+    setSession({
+      data: { user: { id: "usr_1", username: "ana" } },
+      isPending: false,
+    });
+
+    render(<Header />);
+
+    const link = screen.getByRole("link", { name: "ana" });
+    expect(link).toHaveAttribute("href", "/me");
+  });
+
+  it("does not show a /me link when anonymous", () => {
+    render(<Header />);
+
+    expect(screen.queryByRole("link", { name: /\/me/i })).not.toBeInTheDocument();
+    expect(
+      screen.getAllByRole("link").find((el) => el.getAttribute("href") === "/me"),
+    ).toBeUndefined();
+  });
+
+  it("hides the /me link while session is still loading", () => {
+    setSession({ data: null, isPending: true });
+
+    render(<Header />);
+
+    expect(
+      screen.queryAllByRole("link").find((el) => el.getAttribute("href") === "/me"),
+    ).toBeUndefined();
+  });
+});

--- a/apps/web/src/components/header.tsx
+++ b/apps/web/src/components/header.tsx
@@ -40,6 +40,11 @@ export default function Header() {
             >
               Reportar
             </Link>
+            {session?.user?.username && (
+              <Link to="/me" className="text-white">
+                {session.user.username}
+              </Link>
+            )}
             <a href="/" className="text-white" onClick={handleLogout}>
               Sair
             </a>

--- a/apps/web/src/components/me-account.test.tsx
+++ b/apps/web/src/components/me-account.test.tsx
@@ -1,0 +1,168 @@
+import { screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { deleteMe, getMe } from "@/api/users";
+import { signOut } from "@/lib/auth-client";
+import { renderWithQuery } from "@/test/test-utils";
+import { MeAccount } from "./me-account";
+
+vi.mock("@/api/users", () => ({
+  getMe: vi.fn(),
+  deleteMe: vi.fn(),
+}));
+
+type SessionState = { data: { user: { id: string } } | null; isPending: boolean };
+const sessionState: { current: SessionState } = {
+  current: { data: { user: { id: "usr_1" } }, isPending: false },
+};
+
+vi.mock("@/lib/auth-client", () => ({
+  useSession: () => sessionState.current,
+  signOut: vi.fn(),
+}));
+
+const navigate = vi.fn();
+vi.mock("@tanstack/react-router", () => ({
+  useNavigate: () => navigate,
+}));
+
+const mockedGetMe = vi.mocked(getMe);
+const mockedDeleteMe = vi.mocked(deleteMe);
+const mockedSignOut = vi.mocked(signOut);
+
+function setSession(state: SessionState) {
+  sessionState.current = state;
+}
+
+async function renderLoaded(user = {
+  id: "usr_1",
+  username: "ana",
+  createdAt: "2026-04-25T12:00:00Z",
+}) {
+  mockedGetMe.mockResolvedValueOnce(user);
+  renderWithQuery(<MeAccount />);
+  await screen.findByText(user.username);
+}
+
+describe("MeAccount", () => {
+  beforeEach(() => {
+    vi.useFakeTimers({ toFake: ["Date"] });
+    vi.setSystemTime(new Date("2026-04-28T12:00:00Z"));
+    mockedGetMe.mockReset();
+    mockedDeleteMe.mockReset();
+    mockedSignOut.mockReset();
+    navigate.mockReset();
+    setSession({ data: { user: { id: "usr_1" } }, isPending: false });
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("renders the username once loaded", async () => {
+    mockedGetMe.mockResolvedValueOnce({
+      id: "usr_1",
+      username: "ana",
+      createdAt: "2026-04-25T12:00:00Z",
+    });
+
+    renderWithQuery(<MeAccount />);
+
+    expect(await screen.findByText("ana")).toBeInTheDocument();
+  });
+
+  it("shows when the account was created as relative pt-BR", async () => {
+    mockedGetMe.mockResolvedValueOnce({
+      id: "usr_1",
+      username: "ana",
+      createdAt: "2026-04-25T12:00:00Z",
+    });
+
+    renderWithQuery(<MeAccount />);
+
+    expect(await screen.findByText(/Conta criada há 3 dias/i)).toBeInTheDocument();
+  });
+
+  it("renders a delete-account button once loaded", async () => {
+    mockedGetMe.mockResolvedValueOnce({
+      id: "usr_1",
+      username: "ana",
+      createdAt: "2026-04-25T12:00:00Z",
+    });
+
+    renderWithQuery(<MeAccount />);
+
+    expect(
+      await screen.findByRole("button", { name: /apagar minha conta/i }),
+    ).toBeInTheDocument();
+  });
+
+  it("opens a confirmation dialog when the delete button is clicked", async () => {
+    const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
+    await renderLoaded();
+
+    await user.click(screen.getByRole("button", { name: /apagar minha conta/i }));
+
+    expect(screen.getByRole("dialog")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /cancelar/i })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /confirmar exclusão/i })).toBeInTheDocument();
+    expect(mockedDeleteMe).not.toHaveBeenCalled();
+  });
+
+  it("closes the dialog when cancel is clicked, with no API call", async () => {
+    const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
+    await renderLoaded();
+
+    await user.click(screen.getByRole("button", { name: /apagar minha conta/i }));
+    await user.click(screen.getByRole("button", { name: /cancelar/i }));
+
+    expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+    expect(mockedDeleteMe).not.toHaveBeenCalled();
+  });
+
+  it("deletes the account, signs out, and redirects to / on confirm", async () => {
+    const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
+    mockedDeleteMe.mockResolvedValueOnce(undefined);
+    mockedSignOut.mockResolvedValueOnce(undefined as never);
+    await renderLoaded();
+
+    await user.click(screen.getByRole("button", { name: /apagar minha conta/i }));
+    await user.click(screen.getByRole("button", { name: /confirmar exclusão/i }));
+
+    await vi.waitFor(() => {
+      expect(mockedDeleteMe).toHaveBeenCalledTimes(1);
+    });
+    await vi.waitFor(() => {
+      expect(mockedSignOut).toHaveBeenCalledTimes(1);
+    });
+    await vi.waitFor(() => {
+      expect(navigate).toHaveBeenCalledWith({ to: "/" });
+    });
+  });
+
+  it("shows an error and keeps dialog open if delete fails", async () => {
+    const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
+    mockedDeleteMe.mockRejectedValueOnce(new Error("boom"));
+    await renderLoaded();
+
+    await user.click(screen.getByRole("button", { name: /apagar minha conta/i }));
+    await user.click(screen.getByRole("button", { name: /confirmar exclusão/i }));
+
+    expect(await screen.findByRole("alert")).toHaveTextContent(/erro ao apagar/i);
+    expect(screen.getByRole("dialog")).toBeInTheDocument();
+    expect(mockedSignOut).not.toHaveBeenCalled();
+    expect(navigate).not.toHaveBeenCalled();
+  });
+
+  it("redirects to /login when there is no session", async () => {
+    setSession({ data: null, isPending: false });
+
+    renderWithQuery(<MeAccount />);
+
+    await vi.waitFor(() => {
+      expect(navigate).toHaveBeenCalledWith({ to: "/login" });
+    });
+    expect(mockedGetMe).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/components/me-account.tsx
+++ b/apps/web/src/components/me-account.tsx
@@ -1,0 +1,69 @@
+import { useMutation, useQuery } from "@tanstack/react-query";
+import { useNavigate } from "@tanstack/react-router";
+import { useEffect, useState } from "react";
+
+import { deleteMe, getMe } from "@/api/users";
+import { signOut, useSession } from "@/lib/auth-client";
+import { formatRelative } from "@/lib/relative-time";
+
+export function MeAccount() {
+  const session = useSession();
+  const navigate = useNavigate();
+  const isLoggedIn = Boolean(session.data?.user);
+  const [confirmOpen, setConfirmOpen] = useState(false);
+
+  useEffect(() => {
+    if (!session.isPending && !isLoggedIn) {
+      navigate({ to: "/login" });
+    }
+  }, [session.isPending, isLoggedIn, navigate]);
+
+  const { data } = useQuery({
+    queryKey: ["me"],
+    queryFn: getMe,
+    enabled: isLoggedIn,
+  });
+
+  const deletion = useMutation({
+    mutationFn: async () => {
+      await deleteMe();
+      await signOut();
+    },
+    onSuccess: () => {
+      setConfirmOpen(false);
+      navigate({ to: "/" });
+    },
+  });
+
+  if (!isLoggedIn || !data) return null;
+
+  return (
+    <div>
+      <p>{data.username}</p>
+      <p>Conta criada {formatRelative(data.createdAt)}</p>
+      <button type="button" onClick={() => setConfirmOpen(true)}>
+        Apagar minha conta
+      </button>
+      {confirmOpen && (
+        <div role="dialog" aria-label="Confirmar exclusão de conta">
+          <p>Tem certeza? Esta ação é irreversível.</p>
+          <button
+            type="button"
+            onClick={() => setConfirmOpen(false)}
+            disabled={deletion.isPending}
+          >
+            Cancelar
+          </button>
+          <button
+            type="button"
+            onClick={() => deletion.mutate()}
+            disabled={deletion.isPending}
+          >
+            Confirmar exclusão
+          </button>
+          {deletion.isError && <p role="alert">Erro ao apagar a conta.</p>}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/lib/auth-client.ts
+++ b/apps/web/src/lib/auth-client.ts
@@ -1,9 +1,18 @@
+import { inferAdditionalFields } from "better-auth/client/plugins";
 import { createAuthClient } from "better-auth/react";
 
 import { env } from "@/env";
 
 export const authClient = createAuthClient({
   baseURL: env.API_ROOT,
+  plugins: [
+    inferAdditionalFields({
+      user: {
+        username: { type: "string", required: false },
+        deletedAt: { type: "date", required: false },
+      },
+    }),
+  ],
 });
 
 export const { signIn, signUp, signOut, useSession } = authClient;

--- a/apps/web/src/routeTree.gen.ts
+++ b/apps/web/src/routeTree.gen.ts
@@ -11,6 +11,7 @@
 import { Route as rootRouteImport } from "./routes/__root"
 import { Route as ReportFormRouteImport } from "./routes/report-form"
 import { Route as RegisterRouteImport } from "./routes/register"
+import { Route as MeRouteImport } from "./routes/me"
 import { Route as MapRouteImport } from "./routes/map"
 import { Route as LoginRouteImport } from "./routes/login"
 import { Route as AboutRouteImport } from "./routes/about"
@@ -25,6 +26,11 @@ const ReportFormRoute = ReportFormRouteImport.update({
 const RegisterRoute = RegisterRouteImport.update({
   id: "/register",
   path: "/register",
+  getParentRoute: () => rootRouteImport,
+} as any)
+const MeRoute = MeRouteImport.update({
+  id: "/me",
+  path: "/me",
   getParentRoute: () => rootRouteImport,
 } as any)
 const MapRoute = MapRouteImport.update({
@@ -58,6 +64,7 @@ export interface FileRoutesByFullPath {
   "/about": typeof AboutRoute
   "/login": typeof LoginRoute
   "/map": typeof MapRoute
+  "/me": typeof MeRoute
   "/register": typeof RegisterRoute
   "/report-form": typeof ReportFormRoute
   "/reports/$id": typeof ReportsIdRoute
@@ -67,6 +74,7 @@ export interface FileRoutesByTo {
   "/about": typeof AboutRoute
   "/login": typeof LoginRoute
   "/map": typeof MapRoute
+  "/me": typeof MeRoute
   "/register": typeof RegisterRoute
   "/report-form": typeof ReportFormRoute
   "/reports/$id": typeof ReportsIdRoute
@@ -77,6 +85,7 @@ export interface FileRoutesById {
   "/about": typeof AboutRoute
   "/login": typeof LoginRoute
   "/map": typeof MapRoute
+  "/me": typeof MeRoute
   "/register": typeof RegisterRoute
   "/report-form": typeof ReportFormRoute
   "/reports/$id": typeof ReportsIdRoute
@@ -88,6 +97,7 @@ export interface FileRouteTypes {
     | "/about"
     | "/login"
     | "/map"
+    | "/me"
     | "/register"
     | "/report-form"
     | "/reports/$id"
@@ -97,6 +107,7 @@ export interface FileRouteTypes {
     | "/about"
     | "/login"
     | "/map"
+    | "/me"
     | "/register"
     | "/report-form"
     | "/reports/$id"
@@ -106,6 +117,7 @@ export interface FileRouteTypes {
     | "/about"
     | "/login"
     | "/map"
+    | "/me"
     | "/register"
     | "/report-form"
     | "/reports/$id"
@@ -116,6 +128,7 @@ export interface RootRouteChildren {
   AboutRoute: typeof AboutRoute
   LoginRoute: typeof LoginRoute
   MapRoute: typeof MapRoute
+  MeRoute: typeof MeRoute
   RegisterRoute: typeof RegisterRoute
   ReportFormRoute: typeof ReportFormRoute
   ReportsIdRoute: typeof ReportsIdRoute
@@ -135,6 +148,13 @@ declare module "@tanstack/react-router" {
       path: "/register"
       fullPath: "/register"
       preLoaderRoute: typeof RegisterRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    "/me": {
+      id: "/me"
+      path: "/me"
+      fullPath: "/me"
+      preLoaderRoute: typeof MeRouteImport
       parentRoute: typeof rootRouteImport
     }
     "/map": {
@@ -180,6 +200,7 @@ const rootRouteChildren: RootRouteChildren = {
   AboutRoute: AboutRoute,
   LoginRoute: LoginRoute,
   MapRoute: MapRoute,
+  MeRoute: MeRoute,
   RegisterRoute: RegisterRoute,
   ReportFormRoute: ReportFormRoute,
   ReportsIdRoute: ReportsIdRoute,

--- a/apps/web/src/routes/me.tsx
+++ b/apps/web/src/routes/me.tsx
@@ -1,0 +1,11 @@
+import { createFileRoute } from "@tanstack/react-router";
+
+import { MeAccount } from "@/components/me-account";
+
+export const Route = createFileRoute("/me")({
+  component: MeRoute,
+});
+
+function MeRoute() {
+  return <MeAccount />;
+}


### PR DESCRIPTION
## Summary
- Closes #56 — rota `/me`: `<MeAccount />` com guard anônimo→`/login`, exibe `username` + `createdAt` relativo, modal de confirmação → `deleteMe()` + `signOut()` + redirect `/`
- Closes #57 — header: link clicável com `username` apontando p/ `/me` quando logado
- `auth-client.ts`: adiciona `inferAdditionalFields` plugin p/ tipar `session.user.username` (espelha `additionalFields` do server)

## Test plan
- [x] `pnpm --filter @itareport/web test` (31/31 passa, 11 testes novos)
- [x] `pnpm exec tsc --noEmit` limpo
- [x] `pnpm exec vite build` ok (route tree regenerado)
- [ ] Manual: `/me` anônimo redireciona; logado mostra dados; modal confirma → conta apagada + redirect; header mostra username quando logado